### PR TITLE
Remap "Z" to "CTRL". Restore "W"

### DIFF
--- a/boards/shields/stratapad/stratapad.keymap
+++ b/boards/shields/stratapad/stratapad.keymap
@@ -8,11 +8,11 @@
 
         default_layer {
             bindings = <
-                &kp LCTRL 
+				&kp W 
 				&kp A 
 				&kp S 
 				&kp D 
-				&kp Z
+				&kp LCTRL
             >;
         };
     };


### PR DESCRIPTION
Hey, I think the latest firmware had an oopsie as well (mapped "LCTRL" to the Up arrow), so here's the fix my board needed!